### PR TITLE
kernel/stat.hがkernel/types.hをincludeするように変更

### DIFF
--- a/kernel/stat.h
+++ b/kernel/stat.h
@@ -1,3 +1,5 @@
+#include "types.h"
+
 #define T_DIR     1   // Directory
 #define T_FILE    2   // File
 #define T_DEVICE  3   // Device


### PR DESCRIPTION
現状だとpingpong.cなどをコードフォーマットにかけた際に, kernel/stat.hとkernel/types.hの順番の前後関係によって```make qemu```が通らないということが起きました。
コードを眺めたところ、stat.hはtypes.hに依存しているため、これをincludeした方がよいと考えました。
細かい点ですがpull requestを出すことにしました。
よろしくお願いします。